### PR TITLE
Исправлен путь копирования файла recovery.fstab

### DIFF
--- a/p1m.mk
+++ b/p1m.mk
@@ -10,7 +10,7 @@ endif
 
 PRODUCT_COPY_FILES += \
     $(LOCAL_PATH)/recovery/kernel:kernel \
-    $(LOCAL_PATH)/recovery/recovery.fstab:root/recovery.fstab
+    $(LOCAL_PATH)/recovery/recovery.fstab:recovery/root/etc/recovery.fstab
 
 $(call inherit-product, build/target/product/full.mk)
 


### PR DESCRIPTION
Изменён путь копирования файла recovery.fstab в соответствующую папку (/recovery/root/etc/).
